### PR TITLE
Use async status function to query java and fallback to status

### DIFF
--- a/cogs/status.py
+++ b/cogs/status.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Kevin Patino
-# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2023 py-mine
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 
 import asyncio
 import logging
@@ -7,10 +8,115 @@ import logging
 import disnake
 from disnake.ext import commands
 from mcstatus import JavaServer
+from mcstatus.status_response import JavaStatusResponse
+from mcstatus.querier import QueryResponse
 
 from config import Config
 
 module_logger = logging.getLogger(f'__main__.{__name__}')
+
+
+async def status(host: str) -> JavaStatusResponse | QueryResponse:
+    """
+    Get status from server, which can be a normal status or query
+
+    The function will ping server as Java and as Bedrock in one time, and return the first response.
+    """
+    success_task = await handle_exceptions(*(
+            await asyncio.wait({
+                    asyncio.create_task(handle_java_query(host), name="Get query as Java"),
+                    asyncio.create_task(handle_java_status(host), name="Get status as Java"),
+                },
+                return_when=asyncio.FIRST_EXCEPTION,
+                timeout=5
+            )
+        )
+    )
+
+    if success_task is None:
+        raise ValueError("No tasks were successful. Is server offline?")
+
+    return success_task.result()
+
+
+async def latency(host: str) -> float:
+    """
+    Get status from server, which can be Java or Bedrock.
+
+    The function will ping server as Java and as Bedrock in one time, and return the first response.
+    """
+    success_task = await handle_exceptions(*(
+            await asyncio.wait({
+                    asyncio.create_task(handle_latency(host), name="Get server latency"),
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        )
+    )
+
+    if success_task is None:
+        raise ValueError("No tasks were successful. Is server offline?")
+
+    return success_task.result()
+
+
+async def handle_exceptions(done: set[asyncio.Task], pending: set[asyncio.Task]) -> asyncio.Task | None:
+    """
+    Handle exceptions from tasks.
+
+    Also, cancel all pending tasks, if found correct one.
+    """
+    if len(done) == 0:
+        raise ValueError("No tasks was given to `done` set.")
+
+    for i, task in enumerate(done):
+        if task.exception() is not None:
+            if len(pending) == 0:
+                continue
+
+            if i == len(done) - 1:  # firstly check all items from `done` set, and then handle pending set
+                return await handle_exceptions(*(await asyncio.wait(pending, return_when=asyncio.FIRST_EXCEPTION)))
+        else:
+            for pending_task in pending:
+                pending_task.cancel()
+            return task
+
+
+async def handle_java_status(host: str) -> JavaStatusResponse | None:
+    """A wrapper around mcstatus, to compress it in one function."""
+    try:
+        async with asyncio.timeout(3):
+            return await (await JavaServer.async_lookup(host)).async_status()
+    except TimeoutError:
+        module_logger.debug("Timed out, something went wrong. Is the server down?")
+        raise
+    except ValueError:
+        module_logger.debug("Did not succeed, is the server down?")
+        raise
+    except Exception as e:
+        module_logger.debug(e)
+        raise
+
+
+async def handle_java_query(host: str) -> QueryResponse | None:
+    """A wrapper around mcstatus, to compress it in one function."""
+    try:
+        async with asyncio.timeout(3):
+            return await (await JavaServer.async_lookup(host)).async_query()
+    except TimeoutError:
+        module_logger.debug("Query timed out, does the server have enable-query=false?")
+        raise
+    except ValueError:
+        module_logger.debug("Query did not succeed, does the server provided exist?")
+        raise
+    except Exception as e:
+        module_logger.debug(e)
+        raise
+
+
+async def handle_latency(host: str) -> float:
+    """A wrapper around mcstatus, to compress it in one function."""
+    return await (await JavaServer.async_lookup(host)).async_ping()
 
 
 async def status_embed(server_address: str) -> disnake.Embed:
@@ -24,49 +130,53 @@ async def status_embed(server_address: str) -> disnake.Embed:
         embed: Server status information
     """
 
+    error_embed = disnake.Embed(title=server_address,
+                                description="Could not contact server",
+                                colour=disnake.Colour.red())
     try:
-        module_logger.info(f'Looking up Minecraft server "{server_address}"')
-        server = JavaServer.lookup(server_address)
-        server_status = await server.async_status()
-        module_logger.debug(f'Succesful lookup of "{server_address}"')
-        module_logger.debug(f'{server_status.raw}')
-        module_logger.debug(f'Pinging "{server_address}"')
-        server_latency = round(server_status.latency, 2)
-        module_logger.debug(f'Got a latency of {server_latency}ms')
-        server_status_embed = disnake.Embed(
-            title=server_address,
-            description=server_status.version.name,
-            colour=disnake.Colour.green())
-        server_status_embed.add_field(
-            name='Description',
-            value=f'```\u200b{server_status.description}```',  # Unicode blank prevents an empty "value"
-            inline=False)
-        server_status_embed.add_field(
-            name='Count',
-            value=f'{server_status.players.online}/{server_status.players.max}',
-            inline=True)
+        server_status = await status(server_address)
 
-        try:
-            module_logger.info(f'Querying server at {server_address}')
-            query = await server.async_query()
-            module_logger.info(f'Successfully queried server at {server_address}')
-            server_players = (', '.join(query.players.names))
+        if isinstance(server_status, QueryResponse):
+            module_logger.debug("Sending QueryResponse")
+            server_latency = await latency(server_address)  # Query doesn't provide latency
+            server_status_embed = disnake.Embed(
+                title=server_address,
+                description=f'{server_status.software.brand} {server_status.software.version}',
+                colour=disnake.Colour.green())
             server_status_embed.add_field(
-                name='Players',
-                value=f'\u200b{server_players}',  # Unicode blank prevents an empty "value"
+                name='Description',
+                value=f'```\u200b{server_status.motd.to_minecraft().encode("iso-8859-1").decode("utf-8")}```',  # Unicode blank prevents an empty "value"
+                inline=False)
+            server_status_embed.add_field(
+                name='Count',
+                value=f'{server_status.players.online}/{server_status.players.max}',
                 inline=True)
-            server_status_embed.set_footer(text=f'Ping: {server_latency} ms')
+            server_status_embed.set_footer(text=f'Ping: {int(server_latency)} ms')
             return server_status_embed
 
-        except asyncio.exceptions.TimeoutError:
-            module_logger.warn(f'Failed to query server at {server_address}')
-            module_logger.warn(f'Fallback to lookup instead for {server_address}')
-            server_status_embed.set_footer(text=f'Ping: {server_latency} ms')
+        elif isinstance(server_status, JavaStatusResponse):
+            module_logger.debug("Sending JavaStatusResponse, did QueryResponse fail?")
+            server_status_embed = disnake.Embed(
+                title=server_address,
+                description=server_status.version.name,
+                colour=disnake.Colour.green())
+            server_status_embed.add_field(
+                name='Description',
+                value=f'```\u200b{server_status.description}```',  # Unicode blank prevents an empty "value"
+                inline=False)
+            server_status_embed.add_field(
+                name='Count',
+                value=f'{server_status.players.online}/{server_status.players.max}',
+                inline=True)
+            server_status_embed.set_footer(text=f'Ping: {int(server_status.latency)} ms')
             return server_status_embed
 
-    except asyncio.exceptions.TimeoutError:
-        module_logger.warn(f'Could not lookup server at {server_address}')
-        error_embed = disnake.Embed(title='Could not contact server', colour=disnake.Colour.red())
+        else:
+            raise TypeError
+
+    except (asyncio.exceptions.TimeoutError, TypeError, ValueError) as e:
+        module_logger.debug(e)
+        module_logger.warning(f'Could not lookup server at {server_address}')
         return error_embed
 
 


### PR DESCRIPTION
Function taken from a py-mine mcstatus example la neta, no se q hice.
Mostly works for private servers with query enabled. Sometimes works when query is disabled server side.